### PR TITLE
Enabled caching

### DIFF
--- a/public/.htaccess
+++ b/public/.htaccess
@@ -14,3 +14,19 @@
     RewriteCond %{REQUEST_FILENAME} !-f
     RewriteRule ^ index.php [L]
 </IfModule>
+
+<ifmodule mod_expires.c>
+
+<Filesmatch "\.(jpg|jpeg|png|txt|gif|js|css|php|html|swf|ico|woff|mp3)$">
+    ExpiresActive on
+    ExpiresDefault "access plus 1 month"
+</Filesmatch>
+
+# As the downloads page needs to be refreshed frequently.
+
+<Filesmatch "\.(php|html)$">
+    ExpiresActive on
+    ExpiresDefault "access plus 2 hours"
+</Filesmatch>
+
+</ifmodule>


### PR DESCRIPTION
Needs testing as I can't check the changes myself! This should make loading the pages faster after you opened the site ones. All files will be cached for 1 month, but the html and php files will only be cached for 2 hours. This should also make the score of this site at Google Insights higher and so put the site higher in the Google search results list.
